### PR TITLE
Modern Web (Manifest)

### DIFF
--- a/api_test.php
+++ b/api_test.php
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html>
+<html lang="en-us">
 <head>
 	<title>FakeDrink</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,41 +1,46 @@
 {
- "name": "App",
- "icons": [
-  {
-   "src": "\/android-icon-36x36.png",
-   "sizes": "36x36",
-   "type": "image\/png",
-   "density": "0.75"
-  },
-  {
-   "src": "\/android-icon-48x48.png",
-   "sizes": "48x48",
-   "type": "image\/png",
-   "density": "1.0"
-  },
-  {
-   "src": "\/android-icon-72x72.png",
-   "sizes": "72x72",
-   "type": "image\/png",
-   "density": "1.5"
-  },
-  {
-   "src": "\/android-icon-96x96.png",
-   "sizes": "96x96",
-   "type": "image\/png",
-   "density": "2.0"
-  },
-  {
-   "src": "\/android-icon-144x144.png",
-   "sizes": "144x144",
-   "type": "image\/png",
-   "density": "3.0"
-  },
-  {
-   "src": "\/android-icon-192x192.png",
-   "sizes": "192x192",
-   "type": "image\/png",
-   "density": "4.0"
-  }
- ]
+  "name": "Webdrink",
+  "short_name": "Drink",
+  "lang": "en-us",
+  "theme_color": "#a31774",
+  "background_color": "#ffffff",
+  "display": "standalone",
+  "icons": [
+    {
+      "src": "icons/android-icon-36x36.png",
+      "sizes": "36x36",
+      "type": "image\/png",
+      "density": "0.75"
+    },
+    {
+      "src": "icons/android-icon-48x48.png",
+      "sizes": "48x48",
+      "type": "image\/png",
+      "density": "1.0"
+    },
+    {
+      "src": "icons/android-icon-72x72.png",
+      "sizes": "72x72",
+      "type": "image\/png",
+      "density": "1.5"
+    },
+    {
+      "src": "icons/android-icon-96x96.png",
+      "sizes": "96x96",
+      "type": "image\/png",
+      "density": "2.0"
+    },
+    {
+      "src": "icons/android-icon-144x144.png",
+      "sizes": "144x144",
+      "type": "image\/png",
+      "density": "3.0"
+    },
+    {
+      "src": "icons/android-icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image\/png",
+      "density": "4.0"
+    }
+  ]
 }

--- a/iframe_test.php
+++ b/iframe_test.php
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html>
+<html lang="en-us">
 <head>
 	<title>WebDrink iFrame</title>
 </head>

--- a/index.php
+++ b/index.php
@@ -32,7 +32,7 @@ $user_data['ibutton'] = $data[0]["ibutton"][0];
 
 ?>
 <!DOCTYPE HTML>
-<html ng-app="WebDrink">
+<html ng-app="WebDrink" lang="en-us">
 <head>
 	<title>WebDrink</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -52,9 +52,9 @@ $user_data['ibutton'] = $data[0]["ibutton"][0];
     <link rel="icon" type="image/png" sizes="96x96" href="assets/icons/favicon-96x96.png">
     <link rel="icon" type="image/png" sizes="16x16" href="assets/icons/favicon-16x16.png">
     <link rel="manifest" href="assets/manifest.json">
-    <meta name="msapplication-TileColor" content="#ffffff">
+    <meta name="msapplication-TileColor" content="#a31774">
     <meta name="msapplication-TileImage" content="assets/ms-icon-144x144.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#a31774">
 
 	<!-- Styles -->
 	<link href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet" media="screen" type="text/css"/>
@@ -111,7 +111,7 @@ $user_data['ibutton'] = $data[0]["ibutton"][0];
 					<span class="icon-bar"></span>
 					<span class="icon-bar"></span>
 				</button>
-				<a class="navbar-brand" href="#/machines"><img src="assets/icons/webdrink-icon.svg" class="navbar-brand-icon">WebDrink</a>
+				<a class="navbar-brand" href="#/machines"><img src="assets/icons/webdrink-icon.svg" class="navbar-brand-icon" alt="WebDrink">WebDrink</a>
 			</div>
 			<div id="navbar" class="collapse navbar-collapse">
 				<ul class="nav navbar-nav">

--- a/index_small.php
+++ b/index_small.php
@@ -32,7 +32,7 @@ $user_data['ibutton'] = $data[0]["ibutton"][0];
 
 ?>
 <!DOCTYPE HTML>
-<html ng-app="WebDrink">
+<html ng-app="WebDrink" lang="en-us">
 <head>
 	<title>WebDrink 2.0</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
I updated some basic "Modern Web" options that WebDrink wasn't up to date with

Changes:
- Set html language to English
- Set theme color
    - Changing the tab color on chrome mobile (some devices)
- Added manifest details allowing "web app" shortcuts on android